### PR TITLE
refactor: replace deprecated initializationOptions with initialization_options

### DIFF
--- a/LSP-marksman.sublime-settings
+++ b/LSP-marksman.sublime-settings
@@ -1,7 +1,7 @@
 {
     "command": ["${storage_path}/LSP-marksman/bin/${marksman_bin}"],
     "selector": "text.html.markdown",
-    "initializationOptions": {
+    "initialization_options": {
         // How text is synced between this client and the server.
         // 1=full, 2=incremental
         "preferredTextSyncKind": 2,

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -10,7 +10,7 @@
           "definitions": {
             "PluginConfig": {
               "properties": {
-                "initializationOptions": {
+                "initialization_options": {
                   "additionalProperties": false,
                   "properties": {
                     "preferredTextSyncKind": {


### PR DESCRIPTION
In https://github.com/sublimelsp/LSP/releases/tag/4070-2.9.0 `config.init_options`
and `initializationOptions` in settings were deprecated.

(This is a semi-automatically created PR that might not
have been tested manually.)
