### PR TITLE
refactor: add ruff rules for sorting imports

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -1,12 +1,20 @@
-from LSP.plugin import AbstractPlugin, register_plugin, unregister_plugin
+from __future__ import annotations
+
+from LSP.plugin import AbstractPlugin
+from LSP.plugin import register_plugin
+from LSP.plugin import unregister_plugin
 from LSP.plugin.core.protocol import Location
-from LSP.plugin.core.typing import Any, Callable, Dict, Optional, List, Mapping
+from LSP.plugin.core.typing import Any
+from LSP.plugin.core.typing import Callable
+from LSP.plugin.core.typing import Dict
+from LSP.plugin.core.typing import List
+from LSP.plugin.core.typing import Mapping
+from LSP.plugin.core.typing import Optional
 from LSP.plugin.locationpicker import LocationPicker
 from shutil import which
 import os
 import sublime
 import urllib.request
-
 
 MARKSMAN_TAG = '2026-02-08'
 MARKSMAN_RELEASES_BASE = 'https://github.com/artempyanykh/marksman/releases/download/{tag}/{platform}'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,14 @@
+[tool.pyright]
+pythonVersion = "3.8"
+
 [tool.ruff]
-select = ["E", "F", "W"]
 line-length = 120
 target-version = 'py38'
 
 [tool.ruff.lint]
 # Enable preview rules.
 preview = true
-select = ["F401", "I"]
+select = ["E", "F", "I", "W"]
 
 [tool.ruff.lint.isort]
 case-sensitive = false
@@ -22,7 +24,3 @@ module = [
     "sublime"
 ]
 ignore_missing_imports = true
-
-[tool.pyright]
-pythonVersion = "3.8"
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,26 @@ select = ["E", "F", "W"]
 line-length = 120
 target-version = 'py38'
 
+[tool.ruff.lint]
+# Enable preview rules.
+preview = true
+select = ["F401", "I"]
+
+[tool.ruff.lint.isort]
+case-sensitive = false
+force-single-line = true
+from-first = true
+no-sections = true
+order-by-type = false
+required-imports = ["from __future__ import annotations"]
+
 [[tool.mypy.overrides]]
 module = [
     "LSP.*",
     "sublime"
 ]
 ignore_missing_imports = true
+
+[tool.pyright]
+pythonVersion = "3.8"
+


### PR DESCRIPTION
This is a semi-automatically created PR that adds ruff configuration for imports formatting.

It matches configuration included in the LSP package with the intention of consolidating import style across all LSP packages.

If you have strong preference to a different style, please keep the configuration but update it to your liking so that anyone working on the package does not have to guess the correct style to use. See [ruff isort settings](https://docs.astral.sh/ruff/settings/#lintisort).

(Since this PR was created semi-automatically, it might require some changes before being considered ready.)